### PR TITLE
Add GitHub Actions workflow for Docker image build and push

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,31 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}/mtproto-proxy:latest

--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
 # MT2Socks5
+
+## Docker Image Usage
+
+### Pulling the Docker Image
+
+To pull the Docker image from GitHub Packages, use the following command:
+
+```sh
+docker pull ghcr.io/nick3/mtproto-proxy:latest
+```
+
+### Running the Docker Container
+
+To run the Docker container, use the following command:
+
+```sh
+docker run -d \
+  --name mtproto-proxy \
+  -p 8443:443 \
+  -v $(pwd)/redsocks.conf:/etc/redsocks.conf \
+  ghcr.io/nick3/mtproto-proxy:latest
+```
+
+### Configuring redsocks.conf
+
+Make sure to configure the `redsocks.conf` file according to your needs. The `redsocks.conf` file should be mapped to `/etc/redsocks.conf` inside the container.
+
+### redsocks.conf Example
+
+Here is an example of a `redsocks.conf` file:
+
+```conf
+base {
+    log_debug = off;
+    log_info = on;
+    daemon = on;
+    redirector = iptables;
+}
+
+redsocks {
+    local_ip = 127.0.0.1;
+    local_port = 12345;
+
+    ip = [SOCKS5代理IP];  # 您的 SOCKS5 代理的 IP
+    port = [SOCKS5代理端口];  # 您的 SOCKS5 代理的端口
+    type = socks5;
+    login = "";  # 如需认证，请填写用户名
+    password = "";  # 如需认证，请填写密码
+}
+```


### PR DESCRIPTION
Fixes #1

Add GitHub Actions workflow to build and push Docker image, and update README.md with Docker usage instructions.

* **README.md**
  - Add a section for Docker image usage.
  - Include instructions for pulling the Docker image from GitHub Packages.
  - Provide example `docker run` command.
  - Mention the need to configure `redsocks.conf`.
  - Add `redsocks.conf` file example.

* **.github/workflows/docker-image.yml**
  - Create a GitHub Actions workflow to build and push Docker image.
  - Use `docker/build-push-action` to build and push the image.
  - Trigger the workflow on push to `main` branch.
  - Set up job to run on `ubuntu-latest`.
  - Use `secrets.GITHUB_TOKEN` for authentication.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nick3/MT2Socks5/issues/1?shareId=fbb4acc2-a1e0-48e9-90c0-1d9da9381eee).