### PR TITLE
Fix invalid tag error in Docker image task

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -28,4 +28,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository }}/mtproto-proxy:latest
+          tags: ghcr.io/${{ github.repository | toLowerCase }}/mtproto-proxy:latest


### PR DESCRIPTION
Fixes #3

Update the `tags` value in `.github/workflows/docker-image.yml` to use a lowercase repository name.

* Change the `tags` value to `ghcr.io/${{ github.repository | toLowerCase }}/mtproto-proxy:latest` in the `Build and push Docker image` step to avoid the invalid tag error.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nick3/MT2Socks5/issues/3?shareId=48519d9d-35c8-4ef6-9759-ebd1ca5725e5).